### PR TITLE
[codex] Fix Sonar TypeScript config resolution

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.tool-versions'
+          cache: 'npm'
+      - run: npm ci
       - uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,2 @@
 sonar.projectKey=abtion_adonisjs-template_e6981c04-79a9-46d2-9b70-6706c53d1f55
+sonar.typescript.tsconfigPaths=tsconfig.json,inertia/tsconfig.json


### PR DESCRIPTION
## What changed
- install Node dependencies before the Sonar scan runs
- constrain Sonar TypeScript analysis to `tsconfig.json` and `inertia/tsconfig.json`
- keep the Sonar workflow aligned with the repository CI Node version source via `.tool-versions`

## Why
Sonar was scanning before dependencies were installed, while both TypeScript entry configs extend `@adonisjs/tsconfig` from `node_modules`. That can trigger the warning that a referenced or extended `tsconfig.json` was not found and reduce TypeScript analysis accuracy.

## Impact
The Sonar job should now resolve the intended TypeScript configs reliably and analyze the backend and Inertia frontend with the correct compiler settings.

## Validation
- `npx tsc --showConfig -p tsconfig.json`
- `npx tsc --showConfig -p inertia/tsconfig.json`
- direct push to `main` was blocked by repository rules, so this PR goes through the required checks
