### PR TITLE
fix(security): upgrade @adonisjs/http-server 8.0.0 → 8.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -941,19 +941,19 @@
       }
     },
     "node_modules/@adonisjs/http-server": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/http-server/-/http-server-8.0.0.tgz",
-      "integrity": "sha512-j1R15a7jALDOit9iKJ7XnSEdYJEsyiUkm+i0tywWquEOtDZdSSoU28e/cyizvJpW4kkZ3VDiKoLiYUrCA8IXSg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/http-server/-/http-server-8.2.0.tgz",
+      "integrity": "sha512-rqrvPd5RclMB4ubLN85Mj2zl/zFmDl2M1MIjCEbjh0R9iyaVNEvMX0R6FEPmZxxnz4EKAmN3zffHlB0p8j5e1w==",
       "license": "MIT",
       "dependencies": {
-        "@poppinss/macroable": "^1.1.0",
+        "@poppinss/macroable": "^1.1.2",
         "@poppinss/matchit": "^3.2.0",
         "@poppinss/middleware": "^3.2.7",
         "@poppinss/qs": "^6.15.0",
-        "@poppinss/utils": "^7.0.0",
+        "@poppinss/utils": "^7.0.1",
         "@sindresorhus/is": "^7.2.0",
-        "content-disposition": "^1.0.1",
-        "cookie-es": "^2.0.0",
+        "content-disposition": "^1.1.0",
+        "cookie-es": "^3.1.1",
         "destroy": "^1.2.0",
         "encodeurl": "^2.0.0",
         "etag": "^1.8.1",
@@ -994,6 +994,12 @@
         "@poppinss/types": "^1.2.1",
         "flattie": "^1.1.1"
       }
+    },
+    "node_modules/@adonisjs/http-server/node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/@adonisjs/http-server/node_modules/mime-db": {
       "version": "1.54.0",
@@ -4280,9 +4286,9 @@
       }
     },
     "node_modules/@poppinss/macroable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@poppinss/macroable/-/macroable-1.1.0.tgz",
-      "integrity": "sha512-y/YKzZDuG8XrpXpM7Z1RdQpiIc0MAKyva24Ux1PB4aI7RiSI/79K8JVDcdyubriTm7vJ1LhFs8CrZpmPnx/8Pw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@poppinss/macroable/-/macroable-1.1.2.tgz",
+      "integrity": "sha512-FAVBRzzWhYP5mA3lCwLH1A0fKBqq5anyjGet90Z81aRK5c/+LTGUE1zJhZrErjaenBSOOI9BVUs3WVmotneFQA==",
       "license": "MIT"
     },
     "node_modules/@poppinss/matchit": {
@@ -7051,9 +7057,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"


### PR DESCRIPTION
Upgrades @adonisjs/http-server from 8.0.0 to 8.2.0.

Fixes [GHSA-6qvv-pj99-48qm](https://github.com/advisories/GHSA-6qvv-pj99-48qm) — URL Redirection to Untrusted Site ('Open Redirect') via `response.redirect().back()`.

### Verification
- npm update resolved @adonisjs/http-server to 8.2.0
- Build passes
- Tests skipped (user opted out)
- Linter passes
- Typecheck passes