### PR TITLE
Fix security advisories: postcss, @adonisjs/core, lodash-es

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@abtion-oss/design-system-colors": "^1.1.1",
         "@adonisjs/auth": "^10.0.0",
         "@adonisjs/bouncer": "^4.0.0",
-        "@adonisjs/core": "^7.0.1",
+        "@adonisjs/core": "^7.3.2",
         "@adonisjs/cors": "^3.0.0",
         "@adonisjs/i18n": "^3.0.0",
         "@adonisjs/inertia": "^4.1.1",
@@ -81,7 +81,7 @@
         "monocart-coverage-reports": "^2.12.9",
         "pino-pretty": "^13.1.1",
         "playwright": "^1.58.2",
-        "postcss": "^8.5.1",
+        "postcss": "^8.5.13",
         "prettier": "^3.4.2",
         "rimraf": "^6.0.1",
         "sinon": "^21.0.0",
@@ -118,16 +118,16 @@
       "license": "MIT"
     },
     "node_modules/@adonisjs/ace": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@adonisjs/ace/-/ace-14.0.1.tgz",
-      "integrity": "sha512-tvvhCuRJbhlmmzn9p9CsWWUbi4p5dBc9XppI5pQZGE6cl8o4KPJKqWYTVcZT2Q2N03vw8Pg4Ec+2KyO/EotOJw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/ace/-/ace-14.1.0.tgz",
+      "integrity": "sha512-8N8z1YKePBiXz7wLxHFz/HSqjCRSL/9Vzs4XQt8gk8G17u4PXwNncWt0vSgYEcDrvPAt+QOavY1vMeKOOWe29w==",
       "license": "MIT",
       "dependencies": {
-        "@poppinss/cliui": "^6.7.0",
+        "@poppinss/cliui": "^6.8.0",
         "@poppinss/hooks": "^7.3.0",
-        "@poppinss/macroable": "^1.1.0",
+        "@poppinss/macroable": "^1.1.2",
         "@poppinss/prompts": "^3.1.6",
-        "@poppinss/utils": "^7.0.0",
+        "@poppinss/utils": "^7.0.1",
         "fastest-levenshtein": "^1.0.16",
         "jsonschema": "^1.5.0",
         "string-width": "^8.2.0",
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@adonisjs/ace/node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -388,9 +388,9 @@
       }
     },
     "node_modules/@adonisjs/bodyparser": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/bodyparser/-/bodyparser-11.0.0.tgz",
-      "integrity": "sha512-R5WmPtJ2mcv6x755uZmYSHX1eOUr2p/JZpxPYLDqybwwmuvQ5guL79zdBen4euAdc/VLD17sOFyxeuHxikHewQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@adonisjs/bodyparser/-/bodyparser-11.0.1.tgz",
+      "integrity": "sha512-RUpkRRSvCSMLmVJcYUyaAwC9Z1tWlThBvVGiIU5bkWwwe5CcbG2f9sifzod04B+hcgJ4xWSs+FF/WNdbwWFwhQ==",
       "license": "MIT",
       "dependencies": {
         "@poppinss/macroable": "^1.1.0",
@@ -491,30 +491,30 @@
       }
     },
     "node_modules/@adonisjs/core": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@adonisjs/core/-/core-7.0.1.tgz",
-      "integrity": "sha512-3wK3gxwEjkhpz+fKF9RxGk9FZgDekr3TMwZQsMt4XwSH+l2lY6au5Dsz5bepE/9gpbGJ5V9rbusv11YV8PrbIA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@adonisjs/core/-/core-7.3.2.tgz",
+      "integrity": "sha512-rwF9Cdw2CCFODeWUfCb4wjeuQOZIy7Bma1NYA769kVCXyMYoA/QIp86V8PmpwBabdoK4M+JitXgWwAzB9eInGg==",
       "license": "MIT",
       "dependencies": {
-        "@adonisjs/ace": "^14.0.1",
+        "@adonisjs/ace": "^14.1.0",
         "@adonisjs/application": "^9.0.0",
-        "@adonisjs/bodyparser": "^11.0.0",
+        "@adonisjs/bodyparser": "^11.0.1",
         "@adonisjs/config": "^6.1.0",
         "@adonisjs/env": "^7.0.0",
-        "@adonisjs/events": "^10.1.0",
+        "@adonisjs/events": "^10.2.0",
         "@adonisjs/fold": "^11.0.0",
-        "@adonisjs/hash": "^10.0.0",
+        "@adonisjs/hash": "^10.1.0",
         "@adonisjs/health": "^3.1.0",
-        "@adonisjs/http-server": "^8.0.0",
-        "@adonisjs/http-transformers": "^2.3.0",
-        "@adonisjs/logger": "^7.1.0",
+        "@adonisjs/http-server": "^8.2.0",
+        "@adonisjs/http-transformers": "^2.3.1",
+        "@adonisjs/logger": "^7.1.1",
         "@adonisjs/repl": "^5.0.0",
         "@boringnode/encryption": "^1.0.0",
         "@poppinss/colors": "^4.1.6",
         "@poppinss/dumper": "^0.7.0",
-        "@poppinss/macroable": "^1.1.0",
-        "@poppinss/utils": "^7.0.0",
-        "@sindresorhus/is": "^7.2.0",
+        "@poppinss/macroable": "^1.1.2",
+        "@poppinss/utils": "^7.0.1",
+        "@sindresorhus/is": "^8.0.0",
         "@types/he": "^1.2.3",
         "error-stack-parser-es": "^1.0.5",
         "he": "^1.2.0",
@@ -571,6 +571,18 @@
         "@poppinss/string": "^1.7.1",
         "@poppinss/types": "^1.2.1",
         "flattie": "^1.1.1"
+      }
+    },
+    "node_modules/@adonisjs/core/node_modules/@sindresorhus/is": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.0.0.tgz",
+      "integrity": "sha512-YvOsokBE5NsyHuXMnwEVB7lgFk6lX8F4OXCruYVgFII0hUHof0RGUvhMoabVt9hRqbg+qVzayzEG24RCcxcYeA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@adonisjs/core/node_modules/ansi-regex": {
@@ -804,9 +816,9 @@
       }
     },
     "node_modules/@adonisjs/events": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@adonisjs/events/-/events-10.1.0.tgz",
-      "integrity": "sha512-RGMj9711BxCRFngmSV35uyP50Nhk3TMw2wCUw4409qMyWIvd6lMFlHotdhTkV+yTtc2waZE7+gMpgq6k1N7fKQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/events/-/events-10.2.0.tgz",
+      "integrity": "sha512-SzwzbmTLsybSZd47zZMZ3df7puwhY7D8vZ5Uy79SiHjLKbr2eVzUuKjjoYB6/0pZu6IwK9Qx06dI43sl+tLoDw==",
       "license": "MIT",
       "dependencies": {
         "@poppinss/utils": "^7.0.0",
@@ -4178,18 +4190,20 @@
       }
     },
     "node_modules/@poppinss/cliui": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@poppinss/cliui/-/cliui-6.7.0.tgz",
-      "integrity": "sha512-ihlhDUHw4Lfx6Euo8SSDar/rHHD8T1aFXJ1Z3NYSYjHcr9rSK5iy6zC5xvQJCeGY1BTninW520iKv/hd4lS0tA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/cliui/-/cliui-6.8.1.tgz",
+      "integrity": "sha512-o/ssbwr+r6woG65rk9eFHnn9dVUphZr/Rk+4+05ENVMBWYpYhTJGdE9RobTG5JLFubvO4gWIyFeNlC+I4EM6eA==",
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.6",
+        "cli-boxes": "^4.0.1",
         "cli-table3": "^0.6.5",
-        "cli-truncate": "^5.1.1",
-        "log-update": "^7.0.2",
+        "cli-truncate": "^5.2.0",
+        "log-update": "^7.2.0",
         "pretty-hrtime": "^1.0.3",
-        "string-width": "^8.1.0",
-        "supports-color": "^10.2.2"
+        "string-width": "^8.2.0",
+        "supports-color": "^10.2.2",
+        "terminal-size": "^4.0.1"
       }
     },
     "node_modules/@poppinss/cliui/node_modules/ansi-regex": {
@@ -6757,6 +6771,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
+      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20 <19 || >=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -10128,9 +10154,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -11296,9 +11322,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",
@@ -13492,9 +13518,9 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0"
@@ -14182,6 +14208,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "monocart-coverage-reports": "^2.12.9",
     "pino-pretty": "^13.1.1",
     "playwright": "^1.58.2",
-    "postcss": "^8.5.1",
+    "postcss": "^8.5.13",
     "prettier": "^3.4.2",
     "rimraf": "^6.0.1",
     "sinon": "^21.0.0",
@@ -89,7 +89,7 @@
     "@abtion-oss/design-system-colors": "^1.1.1",
     "@adonisjs/auth": "^10.0.0",
     "@adonisjs/bouncer": "^4.0.0",
-    "@adonisjs/core": "^7.0.1",
+    "@adonisjs/core": "^7.3.2",
     "@adonisjs/cors": "^3.0.0",
     "@adonisjs/i18n": "^3.0.0",
     "@adonisjs/inertia": "^4.1.1",
@@ -133,5 +133,8 @@
       "./app/middleware/*.ts"
     ]
   },
-  "prettier": "@adonisjs/prettier-config"
+  "prettier": "@adonisjs/prettier-config",
+  "overrides": {
+    "lodash-es": "4.18.1"
+  }
 }


### PR DESCRIPTION
## Changes

- **postcss** 8.5.8 → 8.5.13 — fixes XSS via unescaped `</style>` in CSS stringify output (GHSA-qx2v-qp2m-jg93)
- **@adonisjs/core** 7.0.1 → 7.3.2 — pulls `@adonisjs/http-server@^8.2.0` which fixes the open redirect vulnerability (GHSA-6qvv-pj99-48qm)
- **lodash-es** overridden to 4.18.1 — fixes code injection via `_.template` (GHSA-r5fr-rjxr-66jc) and prototype pollution via `_.unset`/`_.omit` (GHSA-f23m-r3pf-42rh). The vulnerable 4.17.23 is pinned by `chevrotain@11` (transitive of `prettier-plugin-edgejs`); no upstream fix available yet.

## Verification

- `npm audit` reports 0 vulnerabilities
- Lint, typecheck, and build all pass locally
- Tests deferred to CI