### PR TITLE
Add env-var interpolation to docker-compose ports

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,8 @@
 TZ=UTC
 HOST=localhost
 APP_KEY=development-app-key-not-used-in-production
+POSTGRES_PORT=5432
+REDIS_PORT=6379
 DATABASE_SERVER=postgres://postgres:@127.0.0.1:5432
 SMTP_HOST=localhost
 SMTP_PORT=2525

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ For added security we want to add basic auth to our review/staging environments.
    - `HTTP_AUTH_USERNAME`
    - `HTTP_AUTH_PASSWORD`
 
+### Custom Docker Ports
+
+Docker services bind to default ports (Postgres 5432, Redis 6379). To use custom host ports (e.g. to run multiple projects simultaneously), set `POSTGRES_PORT` and/or `REDIS_PORT` in `.env.local` and make sure they're exported before running `docker compose`.
+
 ## Contributing
 
 The Abtion AdonisJS Template is maintained by [_Abtioneers_](#about-abtion), but open for anyone to suggest improvements and bugfixes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:15.5-alpine
     ports:
-      - 127.0.0.1:5432:5432
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
@@ -12,7 +12,7 @@ services:
   redis:
     image: redis:6-alpine
     ports:
-      - '127.0.0.1:6379:6379'
+      - "127.0.0.1:${REDIS_PORT:-6379}:6379"
 
   smtp4dev:
     image: rnwood/smtp4dev:v3


### PR DESCRIPTION
Allow unique host ports via `POSTGRES_PORT`/`REDIS_PORT` env vars with 5432/6379 defaults so multiple projects can run simultaneously.

### Changes

- **docker-compose.yml**: Replace hardcoded ports with `${POSTGRES_PORT:-5432}:5432` and `${REDIS_PORT:-6379}:6379`
- **.env**: Add `POSTGRES_PORT=5432` and `REDIS_PORT=6379` defaults
- **README.md**: Add "Custom Docker Ports" section

### Impact

Zero impact for existing developers — defaults are unchanged.